### PR TITLE
Switch to std::unordered_map.

### DIFF
--- a/lib/Dictionary.h
+++ b/lib/Dictionary.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 #include <list>
-#include <map>
+#include <unordered_map>
 #include "IExtract.h"
 #include "ILoad.h"
 #include "Word.h"
@@ -14,7 +14,13 @@ namespace lib {
     {
         ILoad& _loader;
         IExtract& _extractor;
-        std::map<std::string, std::shared_ptr<Word>> _dictionary{};
+        /**
+         * \brief Using std::unordered_map for O(1) lookup. No constraints re memory,
+         * and data set isn't too large so it is a better choice over std::map when
+         * searching for definition/scrabble score.
+         * Using std::shared_ptr<Word> as value as Word is shared by anagram map.
+         */
+        std::unordered_map<std::string, std::shared_ptr<Word>> _dictionary{};
 
     public:
         /**

--- a/lib/IExtract.h
+++ b/lib/IExtract.h
@@ -1,8 +1,8 @@
 ﻿#pragma once
-#include <map>
 #include <list>
-#include "Word.h"
 #include <memory>
+#include <unordered_map>
+#include "Word.h"
 
 namespace lib
 {
@@ -16,7 +16,7 @@ namespace lib
     {
     public:
         virtual ~IExtract() = default;
-        virtual std::map<std::string, std::shared_ptr<Word>> extract(std::istream& content) = 0;
+        virtual std::unordered_map<std::string, std::shared_ptr<Word>> extract(std::istream& content) = 0;
         virtual std::list<std::string> getLongestWords() = 0;
         virtual std::list<std::string> getLogyWords() = 0;
         virtual std::list<std::string> getRhymes(const std::string& word) = 0;

--- a/lib/StringExtractor.cpp
+++ b/lib/StringExtractor.cpp
@@ -21,13 +21,13 @@ StringExtractor::StringExtractor(IPrint& printer, ITask& task) : _printer(printe
 * \param content The stream from source dictionary.
 * \return The dictionary as a map<string, Word> where the key is the word itself.
 */
-map<string, shared_ptr<Word>> StringExtractor::extract(istream& content)
+unordered_map<string, shared_ptr<Word>> StringExtractor::extract(istream& content)
 {
     const auto firstLine = 0;
     const auto lastLine = 2;
     auto currentLine = 0;
 
-    auto output = map<string, shared_ptr<Word>>();
+    auto output = unordered_map<string, shared_ptr<Word>>();
 
     string line;
     string word;

--- a/lib/StringExtractor.h
+++ b/lib/StringExtractor.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
+#include <memory>
 #include "IExtract.h"
 #include "ITask.h"
-#include <memory>
 
 namespace lib
 {
@@ -31,7 +31,7 @@ namespace lib
         * \param content The stream from source dictionary.
         * \return The dictionary as a map<string, Word> where the key is the word itself.
         */
-        std::map<std::string, std::shared_ptr<Word>> extract(std::istream& content) override;
+        std::unordered_map<std::string, std::shared_ptr<Word>> extract(std::istream& content) override;
         /**
          * \brief Returns the longest word/s in the dictionary.
          * \returns The longest word/s in the dictionary.

--- a/test/StringExtractorTests.cpp
+++ b/test/StringExtractorTests.cpp
@@ -35,7 +35,7 @@ namespace stringExtractorTests
 
                 THEN("A corresponding collection of Words is created")
                 {
-                    auto expected = map<string, shared_ptr<Word>>
+                    auto expected = unordered_map<string, shared_ptr<Word>>
                     {
                         { "first", make_shared<Word>(Word("first", "adj", "This is the first definition.", printer)) },
                         { "second", make_shared<Word>(Word("second", "adv", "This is the second definition.", printer)) }
@@ -65,7 +65,7 @@ namespace stringExtractorTests
                 loader.setTestFile(testFile);
 
                 auto& content = loader.load();
-                map<string, shared_ptr<Word>> actual;
+                unordered_map<string, shared_ptr<Word>> actual;
 
                 try
                 {
@@ -93,7 +93,7 @@ namespace stringExtractorTests
                 loader.setTestFile(testFile);
 
                 auto& content = loader.load();
-                map<string, shared_ptr<Word>> actual;
+                unordered_map<string, shared_ptr<Word>> actual;
 
                 try
                 {
@@ -121,7 +121,7 @@ namespace stringExtractorTests
                 loader.setTestFile(testFile);
 
                 auto& content = loader.load();
-                map<string, shared_ptr<Word>> actual;
+                unordered_map<string, shared_ptr<Word>> actual;
 
                 try
                 {

--- a/test/TextFileLoaderTests.cpp
+++ b/test/TextFileLoaderTests.cpp
@@ -45,7 +45,7 @@ namespace textFileLoaderTests
 
                 THEN("The content matches input")
                 {
-                    auto expected = map<string, shared_ptr<Word>>
+                    auto expected = unordered_map<string, shared_ptr<Word>>
                     {
                         { "first", make_shared<Word>(Word("first", "adj", "This is the first definition.", printer)) },
                         { "second", make_shared<Word>(Word("second", "adv", "This is the second definition.", printer)) }


### PR DESCRIPTION
- No need for ordered dictionary for insert or lookup
- O(1) lookup vs O(log n) with `std::map`
- No memory constraints
- Not a large data set
- See http://thispointer.com/map-vs-unordered_map-when-to-choose-one-over-another/