### PR TITLE
Don't print scrabble score when word not found.

### DIFF
--- a/cli/CliUserInterface.cpp
+++ b/cli/CliUserInterface.cpp
@@ -90,7 +90,6 @@ void CliUserInterface::findDefinition()
         
         Logger::log(Output, "Definition for '" + word + "':");
         Logger::log(_dictionary.getDefinition(word));
-        Logger::log(Output, "Scrabble score for '" + word + "': " + to_string(_dictionary.getScrabbleScore(word)));
     }
     while (!isControlChar(word));
 

--- a/lib/DefinitionFormatter.cpp
+++ b/lib/DefinitionFormatter.cpp
@@ -11,5 +11,6 @@ using namespace lib;
 */
 string DefinitionFormatter::format(const Word& word)
 {
-    return WordType::getName(word.getType()) + " " + word.getDefinition();
+    return WordType::getName(word.getType()) + " " + word.getDefinition() +
+        "\nScrabble score for '" + word.getWord() + "': " + to_string(word.getScrabbleScore());
 }

--- a/test/DictionaryTaskTests.cpp
+++ b/test/DictionaryTaskTests.cpp
@@ -2,8 +2,6 @@
 #include "catch.hpp"
 #include "TestDictionaryBuilder.h"
 #include "TestHelpers.h"
-#include "../lib/DefinitionFormatter.h"
-#include "../lib/DefinitionPrinter.h"
 #include "../lib/Dictionary.h"
 
 using namespace std;
@@ -11,7 +9,7 @@ using namespace lib;
 
 namespace dictionaryTaskTests
 {
-    SCENARIO("Find a word definition")
+    SCENARIO("Find a word definition and scrabble score")
     {
         const string foundWord = "first";
         const string type = " [adj]\n";
@@ -27,10 +25,12 @@ namespace dictionaryTaskTests
             {
                 const auto actual = dictionary.getDefinition(foundWord);
 
-                THEN("The definition is printed")
+                THEN("The definition and scrabble score is printed")
                 {
                     const auto expectedType = WordType::getName(Adjective);
-                    const auto expected = expectedType + " " + definition;
+                    const auto expectedScore = dictionary.getScrabbleScore(foundWord);
+                    const auto expected = expectedType + " " + definition + 
+                        "\nScrabble score for '" + foundWord + "': " + to_string(expectedScore);
 
                     REQUIRE(expected == actual);
                 }

--- a/test/TestHelpers.h
+++ b/test/TestHelpers.h
@@ -1,25 +1,40 @@
 ﻿#pragma once
-#include <memory>
 #include <list>
+#include <memory>
 #include "../lib/Word.h"
 
 class TestHelpers
 {
 public:
+    static bool stringContains(const std::string& expected, const std::string& actual)
+    {
+        return actual.find(expected) != std::string::npos;
+    }
     /**
      * \brief Returns true if list of strings contains word.
      * \param list The list to search.
      * \param target The word to search for.
      * \returns True if the list contains the word.
      */
-    static bool listContainsWord(std::list<std::string> list, const std::string& target);
+    static bool listContainsWord(std::list<std::string> list, const std::string& target)
+    {
+        return find(list.begin(), list.end(), target) != list.end();
+    }
     /**
      * \brief Overload which searches list of std::shared_ptr<lib::Word>
      * \param list The list to search.
      * \param target The word to search for.
      * \returns True if the list contains the word. 
      */
-    static bool listContainsWord(std::list<std::shared_ptr<lib::Word>> list, const std::string& target);
+    static bool listContainsWord(std::list<std::shared_ptr<lib::Word>> list, const std::string& target)
+    {
+        for (const auto word : list)
+        {
+            if (word->getWord() == target)
+                return true;
+        }
+        return false;
+    }
     /**
     * \brief Test helper to compare smart ptr managed object equality,
     * see https://stackoverflow.com/a/38391135. Overload for shared_ptr.
@@ -31,7 +46,14 @@ public:
     * both expected and actual objects are the same
     */
     template<class TExpected, class TActual>
-    static bool isSmartPtrEqual(const std::shared_ptr<TExpected> expected, const std::shared_ptr<TActual> actual);
+    static bool isSmartPtrEqual(const std::shared_ptr<TExpected> expected, const std::shared_ptr<TActual> actual)
+    {
+        if (expected == actual)
+            return true;
+        if (expected && actual)
+            return *expected == *actual;
+        return false;
+    }
     /**
     * \brief Test helper to compare smart ptr managed object equality,
     * see https://stackoverflow.com/a/38391135. Overload for unique_ptr.
@@ -43,40 +65,12 @@ public:
     * both expected and actual objects are the same
     */
     template<class TExpected, class TActual>
-    static bool isSmartPtrEqual(const std::unique_ptr<TExpected> expected, const std::unique_ptr<TActual> actual);
-};
-
-inline bool TestHelpers::listContainsWord(std::list<std::string> list, const std::string& target)
-{
-    return find(list.begin(), list.end(), target) != list.end();
-}
-
-inline bool TestHelpers::listContainsWord(std::list<std::shared_ptr<lib::Word>> list, const std::string& target)
-{
-    for (const auto word : list)
+    static bool isSmartPtrEqual(const std::unique_ptr<TExpected> expected, const std::unique_ptr<TActual> actual)
     {
-        if (word->getWord() == target)
+        if (expected == actual)
             return true;
+        if (expected && actual)
+            return *expected == *actual;
+        return false;
     }
-    return false;
-}
-
-template <class TExpected, class TActual>
-bool TestHelpers::isSmartPtrEqual(const std::shared_ptr<TExpected> expected, const std::shared_ptr<TActual> actual)
-{
-    if (expected == actual)
-        return true;
-    if (expected && actual)
-        return *expected == *actual;
-    return false;
-}
-
-template <class TExpected, class TActual>
-bool TestHelpers::isSmartPtrEqual(const std::unique_ptr<TExpected> expected, const std::unique_ptr<TActual> actual)
-{
-    if (expected == actual)
-        return true;
-    if (expected && actual)
-        return *expected == *actual;
-    return false;
-}
+};

--- a/test/WordTests.cpp
+++ b/test/WordTests.cpp
@@ -6,6 +6,7 @@
 #include "../lib/EmptyStringException.h"
 #include "../lib/UnsupportedTypeException.h"
 #include "../lib/Word.h"
+#include "TestHelpers.h"
 
 using namespace std;
 using namespace lib;
@@ -20,7 +21,7 @@ namespace wordTests
     auto formatter = DefinitionFormatter();
     auto printer = DefinitionPrinter(formatter);
 
-    SCENARIO("Word with valid type")
+    SCENARIO("Word getters")
     {
         GIVEN("An entry with a word, valid type and definition")
         {
@@ -36,26 +37,26 @@ namespace wordTests
                 {
                     REQUIRE(testWord == actualWord);
                     REQUIRE(testType == actualType);
-                    REQUIRE(testDefinition == actualDefinition);
+                    REQUIRE(TestHelpers::stringContains(testDefinition, actualDefinition));
                 }
             }
 
-            AND_WHEN("The entry is printed")
+            AND_WHEN("The definition is printed")
             {
                 const auto actual = word.printDefinition();
 
-                THEN("The print output contains a type header with definition")
+                THEN("The output includes the word type")
                 {
                     const auto expectedType = WordType::getName(testType) + " ";
                     const auto expected = expectedType + testDefinition;
 
-                    REQUIRE(expected == actual);
+                    REQUIRE(TestHelpers::stringContains(expected, actual));
                 }
             }
         }
     }
 
-    SCENARIO("Word with invalid type")
+    SCENARIO("Word validation")
     {
         GIVEN("An entry with a word, invalid type and definition")
         {
@@ -76,10 +77,7 @@ namespace wordTests
                 }
             }
         }
-    }
 
-    SCENARIO("Word with empty word")
-    {
         GIVEN("An entry with an empty word, valid type and definition")
         {
             const string emptyWord = "";
@@ -99,10 +97,7 @@ namespace wordTests
                 }
             }
         }
-    }
 
-    SCENARIO("Word with empty type")
-    {
         GIVEN("An entry with a word, empty type, and definition")
         {
             const string emptyType = "";
@@ -123,10 +118,7 @@ namespace wordTests
                 }
             }
         }
-    }
 
-    SCENARIO("Word with empty definition")
-    {
         GIVEN("An entry with a word, valid type, and empty definition")
         {
             const string emptyDefinition = "";
@@ -148,7 +140,7 @@ namespace wordTests
         }
     }
 
-    SCENARIO("Word verb definition printing")
+    SCENARIO("Word definitions")
     {
         GIVEN("A verb Word")
         {
@@ -167,14 +159,11 @@ namespace wordTests
                     const auto expectedType = WordType::getName(Verb) + " ";
                     const auto expected = expectedType + definiton;
 
-                    REQUIRE(expected == actual);
+                    REQUIRE(TestHelpers::stringContains(expected, actual));
                 }
             }
         }
-    }
 
-    SCENARIO("Word noun definition printing")
-    {
         GIVEN("A noun Word")
         {
             const string word = "test";
@@ -192,14 +181,11 @@ namespace wordTests
                     const auto expectedType = WordType::getName(Noun) + " ";
                     const auto expected = expectedType + definiton;
 
-                    REQUIRE(expected == actual);
+                    REQUIRE(TestHelpers::stringContains(expected, actual));
                 }
             }
         }
-    }
 
-    SCENARIO("Word adverb definition printing")
-    {
         GIVEN("An adverb Word")
         {
             const string word = "test";
@@ -217,14 +203,11 @@ namespace wordTests
                     const auto expectedType = WordType::getName(Adverb) + " ";
                     const auto expected = expectedType + definiton;
 
-                    REQUIRE(expected == actual);
+                    REQUIRE(TestHelpers::stringContains(expected, actual));
                 }
             }
         }
-    }
 
-    SCENARIO("Word adjective definition printing")
-    {
         GIVEN("An adjective Word")
         {
             const string word = "test";
@@ -242,14 +225,11 @@ namespace wordTests
                     const auto expectedType = WordType::getName(Adjective) + " ";
                     const auto expected = expectedType + definiton;
 
-                    REQUIRE(expected == actual);
+                    REQUIRE(TestHelpers::stringContains(expected, actual));
                 }
             }
         }
-    }
 
-    SCENARIO("Word preposition definition printing")
-    {
         GIVEN("A preposition Word")
         {
             const string word = "test";
@@ -267,14 +247,11 @@ namespace wordTests
                     const auto expectedType = WordType::getName(Preposition) + " ";
                     const auto expected = expectedType + definiton;
 
-                    REQUIRE(expected == actual);
+                    REQUIRE(TestHelpers::stringContains(expected, actual));
                 }
             }
         }
-    }
 
-    SCENARIO("Word proper noun definition printing")
-    {
         GIVEN("A proper noun Word")
         {
             const string word = "test";
@@ -292,14 +269,11 @@ namespace wordTests
                     const auto expectedType = WordType::getName(ProperNoun) + " ";
                     const auto expected = expectedType + definiton;
 
-                    REQUIRE(expected == actual);
+                    REQUIRE(TestHelpers::stringContains(expected, actual));
                 }
             }
         }
-    }
 
-    SCENARIO("Word noun and verb definition printing")
-    {
         GIVEN("A noun and verb Word")
         {
             const string word = "test";
@@ -317,14 +291,11 @@ namespace wordTests
                     const auto expectedType = WordType::getName(NounAndVerb) + " ";
                     const auto expected = expectedType + definiton;
 
-                    REQUIRE(expected == actual);
+                    REQUIRE(TestHelpers::stringContains(expected, actual));
                 }
             }
         }
-    }
 
-    SCENARIO("Word misc definition printing")
-    {
         GIVEN("A misc Word")
         {
             const string word = "test";
@@ -342,7 +313,7 @@ namespace wordTests
                     const auto expectedType = WordType::getName(Misc) + " ";
                     const auto expected = expectedType + definiton;
 
-                    REQUIRE(expected == actual);
+                    REQUIRE(TestHelpers::stringContains(expected, actual));
                 }
             }
         }


### PR DESCRIPTION
- Fixes #54 
- Append scrabble score to definition
  - When word not found, notify user
  - Score not printed
- Fixed unit tests that involve word definitions
- Better test organisation into appropriate scenarios