### PR TITLE
Filter results with unary predicate expression.

### DIFF
--- a/lib/Dictionary.cpp
+++ b/lib/Dictionary.cpp
@@ -93,8 +93,8 @@ int Dictionary::getScrabbleScore(const std::string& word) const
 }
 
 /**
-* \brief Searches the dictionary for the word. If it exists, will look for anagrams of that word.
-* If it doesn't exist, or no anagrams exist, returns an empty list.
+* \brief Search the dictionary for the word. If it exists, will look for anagrams of that word.
+* If it doesn't exist, returns an empty list.
 * \param word The word to search for anagrams.
 * \returns Anagram/s of the word, if the word exists in the dictionary, else returns an empty list.
 */
@@ -105,18 +105,18 @@ list<shared_ptr<Word>> Dictionary::getWordAnagrams(const string& word) const
     if (it == _dictionary.end())
         return list<shared_ptr<Word>>();
 
-    return getStringAnagrams(word);
+    return _task.getTaskResult(WordAnagrams, word);
 }
 
 /**
-* \brief Searches for any anagrams with the letters. Returns any anagrams that exist,
-* else returns an empty list.
+* \brief Search for anagrams of a string of letters.
+* Returns any anagrams that exist, else returns an empty list.
 * \param letters The letters to search for anagrams.
-* \returns Anagram/s made from the letters, if they exist, else returns an empty list.
+* \returns Anagram/s of the letters, if they exist, else returns an empty list.
 */
 list<shared_ptr<Word>> Dictionary::getStringAnagrams(const string& letters) const
 {
-    return _task.getTaskResult(Anagrams, letters);
+    return _task.getTaskResult(StringAnagrams, letters);
 }
 
 /**

--- a/lib/Dictionary.h
+++ b/lib/Dictionary.h
@@ -81,17 +81,17 @@ namespace lib {
         int getScrabbleScore(const std::string& word) const;
         /**
          * \brief Search the dictionary for the word. If it exists, will look for anagrams of that word.
-         * If it doesn't exist, or no anagrams exist, returns an empty list.
+         * If it doesn't exist, returns an empty list.
          * \param word The word to search for anagrams.
          * \returns Anagram/s of the word, if the word exists in the dictionary, else returns an empty list. 
          */
         std::list<std::shared_ptr<Word>> getWordAnagrams(const std::string& word) const;
         /**
-         * \brief Search for any anagrams of the letters. Returns any anagrams that exist,
-         * else returns an empty list.
-         * \param letters The letters to search for anagrams.
-         * \returns Anagram/s of the letters, if they exist, else returns an empty list. 
-         */
+        * \brief Search for anagrams of a string of letters.
+        * Returns any anagrams that exist, else returns an empty list.
+        * \param letters The letters to search for anagrams.
+        * \returns Anagram/s of the letters, if they exist, else returns an empty list.
+        */
         std::list<std::shared_ptr<Word>> getStringAnagrams(const std::string& letters) const;
         /**
          * \brief Returns how many entries are loaded in the dictionary.

--- a/lib/DictionaryTask.cpp
+++ b/lib/DictionaryTask.cpp
@@ -169,7 +169,12 @@ list<shared_ptr<Word>> DictionaryTask::getRhymes(const string& word)
     if (it == _rhymes.end())
         return list<shared_ptr<Word>>();
 
-    return removeSearchWord(word, it->second);
+    return filterResult(
+        it->second,
+        [word](shared_ptr<Word> const& wordObj)
+        {
+            return wordObj->getWord() == word;
+        });
 }
 
 /**
@@ -187,7 +192,12 @@ list<shared_ptr<Word>> DictionaryTask::getAnagrams(const string& word)
     if (it == _anagrams.end())
         return list<shared_ptr<Word>>();
 
-    return removeSearchWord(word, it->second);
+    return filterResult(
+        it->second,
+        [word](shared_ptr<Word> const& wordObj)
+        {
+            return wordObj->getWord() == word;
+        });
 }
 
 /**
@@ -228,23 +238,18 @@ string DictionaryTask::getAnagramKey(const string& word)
 }
 
 /**
-* \brief Filters out the word being searched from the task result.
-* \param word The word being searched.
-* \param result The result from the task.
-* \return A new result without the word being searched.
+* \brief Filter the results based on a predicate lambda expression.
+* \param result The collection of results from the task.
+* \param predicate The predicate lambda expression, where if true, will exclude the result from the collection.
+* \return A new result after filter is applied.
 */
-list<shared_ptr<Word>> DictionaryTask::removeSearchWord(const string& word, list<shared_ptr<Word>> result)
+template<typename Predicate>
+list<shared_ptr<Word>> DictionaryTask::filterResult(list<shared_ptr<Word>> result, Predicate predicate)
 {
-    // cool solution with lambda from https://stackoverflow.com/a/42723273
-    // and can do filter in place since we're not passing by reference
+    // cool solution from https://stackoverflow.com/a/42723273
+    // adapted to accept a predicate lambda exp for custom filtering
     result.erase(
-        remove_if(
-            result.begin(), 
-            result.end(), 
-            [word](shared_ptr<Word> const& wordObj)
-            {
-                return wordObj->getWord() == word;
-            }),
+        remove_if(result.begin(), result.end(), predicate),
         result.end());
 
     return result;

--- a/lib/DictionaryTask.h
+++ b/lib/DictionaryTask.h
@@ -90,12 +90,13 @@ namespace lib
          */
         static std::string getAnagramKey(const std::string& word);
         /**
-         * \brief Filters out the word being searched from the task result.
-         * \param word The word being searched.
-         * \param result The result from the task.
-         * \return A new result without the word being searched.
-         */
-        static std::list<std::shared_ptr<Word>> removeSearchWord(const std::string& word, std::list<std::shared_ptr<Word>> result);
+        * \brief Filter the results based on a lambda predicate.
+        * \param result The collection of results from the task.
+        * \param predicate The predicate lambda expression, where if true, will exclude the result from the collection.
+        * \return A new result after filter is applied.
+        */
+        template<typename Predicate>
+        static std::list<std::shared_ptr<Word>> filterResult(std::list<std::shared_ptr<Word>> result, Predicate predicate);
         /**
         * \brief Returns true if the word ends with ending.
         * \param word The word to inspect.

--- a/lib/DictionaryTask.h
+++ b/lib/DictionaryTask.h
@@ -70,10 +70,11 @@ namespace lib
         /**
         * \brief Sort word's letters alphabetically, as key to anagram map.
         * If key exists in anagram map, return list value for that key, else return an empty list.
+        * \param taskType Only WordAnagrams or StringAnagrams supported.
         * \param word The word to search for anagrams.
         * \returns Anagram/s of the word, if they exist, else returns an empty list.
         */
-        std::list<std::shared_ptr<Word>> getAnagrams(const std::string& word);
+        std::list<std::shared_ptr<Word>> getAnagrams(TaskType taskType, const std::string& word);
         /**
          * \brief Returns the rhyming part of the word if >= 3 letters,
          * else returns an empty string.

--- a/lib/TaskType.h
+++ b/lib/TaskType.h
@@ -7,6 +7,7 @@ namespace lib
         LongestWords,
         LogyWords,
         Rhymes,
-        Anagrams
+        WordAnagrams,
+        StringAnagrams
     };
 }

--- a/test/DictionaryTaskTests.cpp
+++ b/test/DictionaryTaskTests.cpp
@@ -362,25 +362,25 @@ namespace dictionaryTaskTests
 
     SCENARIO("Find anagrams")
     {
-        const string anagram1 = "tesla";
-        const string anagram2 = "least";
-        const string anagram3 = "slate";
-        const string anagram4 = "steal";
-        const string notAnagram1 = "abcde";
-        const string notAnagram2 = "slat";
-
-        const auto words = list<string>
-        {
-            anagram1,
-            anagram2,
-            anagram3,
-            anagram4,
-            notAnagram1,
-            notAnagram2
-        };
-
         GIVEN("A dictionary with words")
         {
+            const string anagram1 = "tesla";
+            const string anagram2 = "least";
+            const string anagram3 = "slate";
+            const string anagram4 = "steal";
+            const string notAnagram1 = "abcde";
+            const string notAnagram2 = "slat";
+
+            const auto words = list<string>
+            {
+                anagram1,
+                anagram2,
+                anagram3,
+                anagram4,
+                notAnagram1,
+                notAnagram2
+            };
+
             auto builder = TestDictionaryBuilder(words);
             auto dictionary = builder.build();
 
@@ -418,12 +418,12 @@ namespace dictionaryTaskTests
                 }
             }
 
-            AND_WHEN("Anagrams of a collection of letters is requested")
+            AND_WHEN("Anagrams for a collection of letters is requested")
             {
                 const string target = "alset";
                 const auto actual = dictionary.getStringAnagrams(target);
 
-                THEN("Anagrams of the word are returned")
+                THEN("Anagrams of the collection of letters are returned")
                 {
                     REQUIRE(TestHelpers::listContainsWord(actual, anagram1));
                     REQUIRE(TestHelpers::listContainsWord(actual, anagram2));
@@ -446,6 +446,59 @@ namespace dictionaryTaskTests
                 THEN("No anagrams are returned")
                 {
                     REQUIRE(actual.empty());
+                }
+            }
+        }
+
+        GIVEN("A dictionary with anagrams of legal and illegal scrabble words")
+        {
+            const string definition = "\nTest definition.\n\n";
+
+            const string nounWord = "word";
+            const auto nounTypeDef = " [n]" + definition;
+
+            const string miscWord = "dwor";
+            const auto miscTypeDef = " [misc]" + definition;
+
+            const string properNounWord = "rdwo";
+            const auto properNounTypeDef = " [pn]" + definition;
+
+            const string hyphenWord = "w-o-r-d";
+            const auto hyphenTypeDef = " [v]" + definition;
+
+            const auto words = list<string>
+            {
+                nounWord,
+                miscWord,
+                properNounWord,
+                hyphenWord
+            };
+            const auto typeAndDefs = list<string>
+            {
+                nounTypeDef,
+                miscTypeDef,
+                properNounTypeDef,
+                hyphenTypeDef
+            };
+
+            auto builder = TestDictionaryBuilder(words, typeAndDefs);
+            auto dictionary = builder.build();
+
+            WHEN("Anagrams for a collection of letters is requested")
+            {
+                const string target = "drow";
+                const auto actual = dictionary.getStringAnagrams(target);
+
+                THEN("Legal scrabble words are returned")
+                {
+                    REQUIRE(TestHelpers::listContainsWord(actual, nounWord));
+                }
+
+                AND_THEN("Illegal scrabble words are not returned")
+                {
+                    REQUIRE(!TestHelpers::listContainsWord(actual, miscWord));
+                    REQUIRE(!TestHelpers::listContainsWord(actual, properNounWord));
+                    REQUIRE(!TestHelpers::listContainsWord(actual, hyphenWord));
                 }
             }
         }


### PR DESCRIPTION
Fixes #62 

`DictionaryTask::filterResults()` provides a flexible way of filtering results by taking a unary predicate lambda expression as a parameter. If expression is `true`, result is removed from the collection of results.