### PR TITLE
Words with numbers are illegal scrabble words.

### DIFF
--- a/lib/Word.cpp
+++ b/lib/Word.cpp
@@ -47,12 +47,15 @@ string Word::printDefinition() const
 }
 
 /**
-* \brief Returns true if word is not misc, proper noun or hyphenated.
-* \return True if word type is not misc, proper noun or hyphenated.
+* \brief Returns true if word is not misc, proper noun, hyphenated or contains numbers.
+* \return True if word type is not misc, proper noun, hyphenated or contains numbers.
 */
 bool Word::isLegalScrabbleWord() const
 {
-    return !(_type == Misc || _type == ProperNoun || _word.find("-") != string::npos);
+    return !(_type == Misc 
+        || _type == ProperNoun 
+        || _word.find('-') != string::npos 
+        || containsNumbers(_word));
 }
 
 /**
@@ -109,4 +112,26 @@ int Word::calculateScrabbleScore() const
         score += letterScores[toupper(letter) - capitalA];
 
     return score;
+}
+
+/**
+* \brief Deals with edge case where "csp2104" is noun.
+* Checks if a word contains numbers by iterating each
+* letter as uppercase and checking if its ascii value is
+* within range of '0' - '9'.
+* \param word The word to check if it contains numbers.
+* \return true if it contains numbers.
+*/
+bool Word::containsNumbers(const std::string& word)
+{
+    const auto asciiZero = static_cast<int>('0');
+    const auto asciiNine = static_cast<int>('9');
+
+    for (const auto& letter : word)
+    {
+        const auto uppercase = toupper(letter);
+        if (uppercase >= asciiZero && uppercase <= asciiNine)
+            return true;
+    }
+    return false;
 }

--- a/lib/Word.h
+++ b/lib/Word.h
@@ -42,8 +42,8 @@ namespace lib
          */
         void incrementUsage();
         /**
-         * \brief Returns true if usage < 2.
-         * \returns True if usage < 2.
+         * \brief Returns true if usage == 1.
+         * \returns True if usage == 1.
          */
         bool isRareWord() const;
         /**
@@ -59,5 +59,14 @@ namespace lib
         * \returns The score for the word if not misc, proper noun or hyphenated words, else returns 0.
         */
         int calculateScrabbleScore() const;
+        /**
+        * \brief Deals with edge case where "csp2104" is noun.
+        * Checks if a word contains numbers by iterating each
+        * letter as uppercase and checking if its ascii value is
+        * within range of '0' - '9'.
+        * \param word The word to check if it contains numbers.
+        * \return true if it contains numbers.
+        */
+        static bool containsNumbers(const std::string& word);
     };
 }

--- a/test/DictionaryTaskTests.cpp
+++ b/test/DictionaryTaskTests.cpp
@@ -260,6 +260,9 @@ namespace dictionaryTaskTests
         const auto hyphenTypeDef = " [v]" + definition;
         const auto expectedHyphenScore = 0;
 
+        const string wordWithNumber = "abc123";
+        const auto expectedWordWithNumberScore = 0;
+
         const auto words = vector<string>
         {
             adjectiveWord,
@@ -270,7 +273,8 @@ namespace dictionaryTaskTests
             verbWord,
             miscWord,
             properNounWord,
-            hyphenWord
+            hyphenWord,
+            wordWithNumber
         };
         const auto typeAndDefs = vector<string>
         {
@@ -282,7 +286,8 @@ namespace dictionaryTaskTests
             verbTypeDef,
             miscWordTypeDef,
             properNounTypeDef,
-            hyphenTypeDef
+            hyphenTypeDef,
+            nounTypeDef
         };
 
         GIVEN("A dictionary with all word types")
@@ -301,6 +306,7 @@ namespace dictionaryTaskTests
                 auto actualMiscScore = dictionary.getScrabbleScore(miscWord);
                 auto actualProperNounScore = dictionary.getScrabbleScore(properNounWord);
                 auto actualHyphenScore = dictionary.getScrabbleScore(hyphenWord);
+                auto actualWordWithNumberScore = dictionary.getScrabbleScore(wordWithNumber);
 
                 THEN("An adjective word can score")
                 {
@@ -345,6 +351,11 @@ namespace dictionaryTaskTests
                 AND_THEN("A hyphen word can't score")
                 {
                     REQUIRE(expectedHyphenScore == actualHyphenScore);
+                }
+
+                AND_THEN("A word with numbers can't score")
+                {
+                    REQUIRE(expectedWordWithNumberScore == actualWordWithNumberScore);
                 }
             }
 


### PR DESCRIPTION
Fixes #92 
Words with numbers now return zero as scrabble score.